### PR TITLE
Upgrade lemmy-bot and lemmy-js-client version to be compatible with lemmy 0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "inversify": "^6.0.1",
     "inversify-binding-decorators": "^4.0.0",
     "lemmy-bot": "^0.5.1",
-    "lemmy-js-client": "^0.18.1-rc.3",
+    "lemmy-js-client": "0.19.2-alpha.3",
     "moment": "^2.29.4",
     "mysql2": "^3.6.0",
     "pg": "8.2.x",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dotenv": "^16.3.1",
     "inversify": "^6.0.1",
     "inversify-binding-decorators": "^4.0.0",
-    "lemmy-bot": "^0.4.1",
+    "lemmy-bot": "^0.5.1",
     "lemmy-js-client": "^0.18.1-rc.3",
     "moment": "^2.29.4",
     "mysql2": "^3.6.0",

--- a/src/Classes/Services/DeterminesUserPermissions/DeterminesIfUserIsAdmin.ts
+++ b/src/Classes/Services/DeterminesUserPermissions/DeterminesIfUserIsAdmin.ts
@@ -10,6 +10,6 @@ export class DeterminesIfUserIsAdmin {
   public async handle(person: Person): Promise<boolean> {
     const details = await this.client.getDetailsForPerson(person);
 
-    return details.person_view.person.admin;
+    return details.person_view.is_admin;
   }
 }

--- a/src/Classes/ValueObjects/LemmyApi.ts
+++ b/src/Classes/ValueObjects/LemmyApi.ts
@@ -13,8 +13,7 @@ export class LemmyApi {
   ) {}
 
   async createPost(form: Omit<CreatePost, "auth">): Promise<number> {
-    return (await this.client.createPost({ ...form, auth: this.token }))
-      .post_view.post.id;
+    return (await this.client.createPost({ ...form })).post_view.post.id;
   }
 
   async createFeaturedPost(
@@ -36,7 +35,6 @@ export class LemmyApi {
         post_id: postIdentifier,
         featured: featurePost,
         feature_type: featuredType,
-        auth: this.token,
       })
     ).post_view.post.id;
   }
@@ -44,12 +42,11 @@ export class LemmyApi {
   async getDetailsForPerson(person: Person): Promise<GetPersonDetailsResponse> {
     return await this.client.getPersonDetails({
       username: person.name,
-      auth: this.token,
     });
   }
 
   async getCommunityIdentifier(name: string): Promise<number> {
-    return (await this.client.getCommunity({ name: name, auth: this.token }))
-      .community_view.community.id;
+    return (await this.client.getCommunity({ name: name })).community_view
+      .community.id;
   }
 }

--- a/src/Tests/Unit/Services/DeterminesifUserPermissions.test.ts
+++ b/src/Tests/Unit/Services/DeterminesifUserPermissions.test.ts
@@ -125,17 +125,17 @@ describe(DeterminesIfUserIsAdmin, () => {
 
     const person = instance<Person>(mock<Person>());
     const counts = instance<PersonAggregates>(mock<PersonAggregates>());
-    const getPersonInterface = (isAdmin: boolean): Person => {
+    const getPersonInterface = (): Person => {
       return {
         ...person,
-        admin: isAdmin,
       };
     };
 
     const regularUserResponse: GetPersonDetailsResponse = {
       person_view: {
-        person: getPersonInterface(false),
+        person: getPersonInterface(),
         counts: counts,
+        is_admin: false,
       },
       posts: [],
       comments: [],
@@ -144,8 +144,9 @@ describe(DeterminesIfUserIsAdmin, () => {
 
     const adminResponse: GetPersonDetailsResponse = {
       person_view: {
-        person: getPersonInterface(true),
+        person: getPersonInterface(),
         counts: counts,
+        is_admin: true,
       },
       posts: [],
       comments: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,19 +2676,19 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lemmy-bot@^0.4.1:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/lemmy-bot/-/lemmy-bot-0.4.5.tgz#b1f01993a38277c124c220017771aa67c173d24c"
-  integrity sha512-GDf/Qjeig3RcjFgYAlUwsA3/YmOgKZOK0vs15KaPDNjMno+l9JZsb0I7XUuIMCPAHZUlSdSBuS9kLJzE9LouAA==
+lemmy-bot@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/lemmy-bot/-/lemmy-bot-0.5.1.tgz#17075e3e09a6e4010e06634f8332b9c3f129bcb2"
+  integrity sha512-dRguH3qHLHRdnZzZ5MvguVy94k8rz/COvF+KJGkn0OOx/Qhzp/ByDv9vXZh0x9rzkddfVp4ODPZCgEDrDPbJog==
   dependencies:
-    lemmy-js-client "0.18.3-rc.1"
-    node-cron "^3.0.2"
+    lemmy-js-client "0.19.0"
+    node-cron "^3.0.3"
     sqlite3 "^5.1.6"
 
-lemmy-js-client@0.18.3-rc.1:
-  version "0.18.3-rc.1"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.18.3-rc.1.tgz#e256981618d011de04882edbb81ee450bde0f068"
-  integrity sha512-z+ZqPoeJClxh3oQiD7ICgkrLKwFZvxs07a/28rvCouVu5zbhjGu0xXltq0GpgtzqFsGamXZ3tYz66ryzYjPBxg==
+lemmy-js-client@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.0.tgz#50098183264fa176784857f45665b06994b31e18"
+  integrity sha512-h+E8wC9RKjlToWw9+kuGFAzk4Fiaf61KqAwzvoCDAfj2L1r+YNt5EDMOggGCoRx5PlqLuIVr7BNEU46KxJfmHA==
   dependencies:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"
@@ -3006,10 +3006,10 @@ node-addon-api@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
-node-cron@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-3.0.2.tgz#bb0681342bd2dfb568f28e464031280e7f06bd01"
-  integrity sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==
+node-cron@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/node-cron/-/node-cron-3.0.3.tgz#c4bc7173dd96d96c50bdb51122c64415458caff2"
+  integrity sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==
   dependencies:
     uuid "8.3.2"
 
@@ -3978,13 +3978,8 @@ unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
   integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
-
-unique-slug@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
-  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
-    imurmurhash "^0.1.4"
+    unique-slug "^2.0.0"
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2693,10 +2693,10 @@ lemmy-js-client@0.19.0:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"
 
-lemmy-js-client@^0.18.1-rc.3:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.18.1.tgz#28df266eded0ef4a72b05ee6eabebddadfd81a27"
-  integrity sha512-maafUZ9ZJkXthRZmM0+limJmymF2kmN/8SiKufS3V4OVNM72s+wUFFiyhKmA370g23iZRW6SUagE7jNKnqNyYQ==
+lemmy-js-client@0.19.2-alpha.3:
+  version "0.19.2-alpha.3"
+  resolved "https://registry.yarnpkg.com/lemmy-js-client/-/lemmy-js-client-0.19.2-alpha.3.tgz#644bf9f2bf406b08342ea10f8e325953112f628a"
+  integrity sha512-SqI/S4mPsbo35Yo1ODYP4vhj5lGlci73KKdQigaT+6hO8SQaeATcMBV3RBxUYswNGGLN4vN+sCvavGoATfkqCw==
   dependencies:
     cross-fetch "^3.1.5"
     form-data "^4.0.0"
@@ -3980,6 +3980,13 @@ unique-filename@^1.1.1:
   integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
   dependencies:
     unique-slug "^2.0.0"
+
+unique-slug@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+  dependencies:
+    imurmurhash "^0.1.4"
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"


### PR DESCRIPTION
- Upgraded lemmy-bot's version to ^0.5.1.
- Upgraded lemmy-js-client's version to 0.19.2-alpha.3, as per the version required by lemmy-bot 0.5.1. I am unsure if it only works with this specific version, so I specifically wrote the exact version instead of using ^0.19.2. 
- Upgraded codebase to match the updated implementations of lemmy-js-client (e.g. interface property updates, function param updates)